### PR TITLE
[BUGFIX] DatamapHook > Catch SiteNotFoundException

### DIFF
--- a/Classes/Backend/Hook/DatamapHook.php
+++ b/Classes/Backend/Hook/DatamapHook.php
@@ -286,7 +286,14 @@ class DatamapHook
 
         /** @var SiteFinder $siteFinder */
         $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
-        $site = $siteFinder->getSiteByPageId($pageId);
+        try {
+            $site = $siteFinder->getSiteByPageId($pageId);
+        } catch (SiteNotFoundException $exception) {
+            $site = current($siteFinder->getAllSites());
+            if (empty($site)) {
+                throw new SiteNotFoundException('No site found in root line of page ' . $pageId, 1587472422);
+            }
+        }
 
         [$siteHost, $sitePath] = $this->getBaseByPageId($site, $pageId, $languageId);
         $currentSlug = BackendUtility::getRecord('pages', $pageId, 'slug')['slug'] ?? '';


### PR DESCRIPTION
Prevents a critical error when editing page titles that do not have root page

![Selection_228](https://user-images.githubusercontent.com/38720734/79867606-46fea900-83e7-11ea-854f-52804cfb4a39.png)
