### PR TITLE
[BUGFIX] Fix value for empty redirect lifetime

### DIFF
--- a/Classes/Backend/Hook/DatamapHook.php
+++ b/Classes/Backend/Hook/DatamapHook.php
@@ -339,7 +339,7 @@ class DatamapHook
                 'createdon' => time(),
                 'updatedon' => time(),
                 'createdby' => $this->getBackendUserId(),
-                'endtime' => $redirectLifetime !== false ? $redirectLifetime : '',
+                'endtime' => $redirectLifetime !== false ? $redirectLifetime : 0,
                 'source_host' => $siteHost,
                 'source_path' => $path,
                 'target_statuscode' => in_array($redirectHttpStatusCode, [301, 307],


### PR DESCRIPTION
This is necessary to prevent an error for strict database environments as the field 'endtime' is an integer.

![image](https://user-images.githubusercontent.com/15915048/79898649-e6359780-840b-11ea-9957-9d447ebdc5b6.png)
