### PR TITLE
[TASK] Ensures that pid is integer

### DIFF
--- a/Classes/Backend/Hook/DatamapHook.php
+++ b/Classes/Backend/Hook/DatamapHook.php
@@ -89,7 +89,7 @@ class DatamapHook
                 $fieldConfig = $GLOBALS['TCA']['pages']['columns']['slug']['config'] ?? [];
                 /** @var SlugHelper $helper */
                 $helper = GeneralUtility::makeInstance(SlugHelper::class, 'pages', 'slug', $fieldConfig);
-                $generatedSlug = $slugToCompare = $helper->generate($data, $data['pid']);
+                $generatedSlug = $slugToCompare = $helper->generate($data, (int)$data['pid']);
                 if (!PermissionHelper::hasFullPermission()) {
                     if ($allowOnlyLastSegment) {
                         $slugToCompare = $this->getLastSlugSegment($generatedSlug);


### PR DESCRIPTION
There are cases where the pid element in `$data` is a string and must be converted to int before passing it to `generate()` or else it will raise an exception.