### PR TITLE
[TASK] Adapt InputSlugElement for TYPO3 10.4

### DIFF
--- a/Classes/Backend/Form/InputSlugElement.php
+++ b/Classes/Backend/Form/InputSlugElement.php
@@ -47,7 +47,14 @@ class InputSlugElement extends \TYPO3\CMS\Backend\Form\Element\InputSlugElement
 
             $mountRootPage = PermissionHelper::getTopmostAccessiblePage((int)$this->data['databaseRow']['uid']);
             $inaccessibleSlugSegments = SluggiSlugHelper::getSlug((int)$mountRootPage['pid'], $languageId);
-            $prefix = $this->getPrefix($this->data['site'], $languageId) . $inaccessibleSlugSegments;
+            if (method_exists($this, 'getPrefix')) {
+                // < TYPO3 10.4.0
+                $baseUrl = $this->getPrefix($this->data['site'], $languageId);
+            } else {
+                // >= TYPO3 10.4.0
+                $baseUrl = $this->data['customData'][$this->data['fieldName']]['slugPrefix'] ?? '';
+            }
+            $prefix = $baseUrl . $inaccessibleSlugSegments;
             $editableSlugSegments = $this->data['databaseRow']['slug'];
             $allowOnlyLastSegment = (bool)Configuration::get('last_segment_only');
             if (!empty($inaccessibleSlugSegments) && strpos($editableSlugSegments, $inaccessibleSlugSegments) === 0) {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.10.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.5-9.5.99',
+            'typo3' => '9.5.5-10.4.99',
         ],
         'suggests' => [
             'redirects' => ''


### PR DESCRIPTION
InputSlugElement::getPrefix() no longer exists in 10.4