### PR TITLE
Rebuild redirect caches after slug update

### DIFF
--- a/Classes/Backend/Service/SlugService.php
+++ b/Classes/Backend/Service/SlugService.php
@@ -13,7 +13,10 @@ use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\Model\CorrelationId;
 use TYPO3\CMS\Core\Routing\InvalidRouteArgumentsException;
 use TYPO3\CMS\Core\Routing\PageRouter;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Redirects\Service\RedirectCacheService;
+
 use function rtrim;
 
 /**
@@ -73,6 +76,11 @@ class SlugService extends \TYPO3\CMS\Redirects\Service\SlugService
                 $this->checkSubPages($currentPageRecord, $currentSlug, $newSlug);
             }
             $this->sendNotification();
+        }
+
+        if ($this->autoCreateRedirects && ExtensionManagementUtility::isLoaded('redirects')) {
+            // Rebuild redirect cache
+            GeneralUtility::makeInstance(RedirectCacheService::class)->rebuild();
         }
     }
 


### PR DESCRIPTION
I've re-introduced the `RedirectCacheService::rebuild` inside the `rebuildSlugsForSlugChange` function. Because the redirects aren't created using the DataHandler, and the slug changes from within the page properties or pagetree aren't handled by the DataHandler too, we have to rebuild the RedirectCache after the slug has been updated and redirects might have been created (based on the `autoCreateRedirects`).

To be sure the redirects are working correctly, I chose to rebuild the caches after the slug updates are ready for both the current as well as the child pages. If `autoCreateRedirects` is enabled and the redirects extension is loaded, the redirect caches are rebuild.