### PR TITLE
Add Mount Point to getVariant() URI generation.

### DIFF
--- a/Classes/Backend/Service/SlugService.php
+++ b/Classes/Backend/Service/SlugService.php
@@ -213,7 +213,7 @@ class SlugService extends \TYPO3\CMS\Redirects\Service\SlugService
         // Check for possibly different URL (e.g. with /index.html appended)
         $pageRouter = GeneralUtility::makeInstance(PageRouter::class, $this->site);
         try {
-            $generatedPath = $pageRouter->generateUri($pageId, ['_language' => $languageId])->getPath();
+            $generatedPath = $pageRouter->generateUri($pageId, ['_language' => $languageId, 'MP' => $basePath])->getPath();
         } catch (InvalidRouteArgumentsException $e) {
             $generatedPath = '';
         }

--- a/Classes/Backend/Service/SlugService.php
+++ b/Classes/Backend/Service/SlugService.php
@@ -213,11 +213,13 @@ class SlugService extends \TYPO3\CMS\Redirects\Service\SlugService
         // Check for possibly different URL (e.g. with /index.html appended)
         $pageRouter = GeneralUtility::makeInstance(PageRouter::class, $this->site);
         try {
-            $generatedPath = $pageRouter->generateUri($pageId, ['_language' => $languageId, 'MP' => $basePath])->getPath();
+            $generatedPath = $pageRouter->generateUri($pageId, ['_language' => $languageId])->getPath();
+            $generatedPath = substr($generatedPath, strlen($basePath));
         } catch (InvalidRouteArgumentsException $e) {
             $generatedPath = '';
         }
         $variant = null;
+
         // There must be some kind of route enhancer involved
         if (($generatedPath !== $originalSlug) && strpos($generatedPath, $originalSlug) !== false) {
             $variant = str_replace($originalSlug, '', $generatedPath);


### PR DESCRIPTION
At TUM, we encountered an issue having a mount point differing to the domain like "https://www.my-domain.tld/subpath-as-mount-point" will cause a faulty redirect.

Example
MP: https://www.my-domain.tld/subpath-as-mount-point
Slug: /bob
New Slug: /alice
Source Path: /subpath-as-mount-point/bob/subpath-as-mount-point/
Destination: /subpath-as-mount-point/alice/subpath-as-mount-point/

I added a simple fix by providing $basePath as MP.
