### PR TITLE
Add section 'extra' because auf deprecation warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
     "psr-4": {
       "Wazum\\Sluggi\\": "Classes"
     }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "sluggi",
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "extra": {
     "typo3/cms": {
-      "extension-key": "sluggi",
+      "extension-key": "sluggi"
     }
   }
 }


### PR DESCRIPTION
composer shows this warning:
```
TYPO3 Extension Package "wazum/sluggi", does not define extension key in composer.json.
Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)
```