### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
     "psr-4": {
       "Wazum\\Sluggi\\": "Classes"
     }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "sluggi"
+    }
   }
 }


### PR DESCRIPTION
TYPO3 Extension Package "wazum/sluggi", does not define extension key in composer.json.
Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference