### PR TITLE
[BUGFIX] add missing slash to slug preview

### DIFF
--- a/Classes/Backend/Controller/FormSlugAjaxController.php
+++ b/Classes/Backend/Controller/FormSlugAjaxController.php
@@ -94,7 +94,7 @@ class FormSlugAjaxController extends \TYPO3\CMS\Backend\Controller\FormSlugAjaxC
             if ($allowOnlyLastSegment) {
                 $generatedSegments = explode('/', $slug->generate($recordData, $parentPageId));
                 array_pop($generatedSegments);
-                $proposal = implode('/', $generatedSegments) . str_replace('/', '-', substr($proposal, 1));
+                $proposal = implode('/', $generatedSegments) . '/' . str_replace('/', '-', substr($proposal, 1));
             }
         } else {
             throw new RuntimeException('mode must be either "auto", "recreate" or "manual"', 1535835666);


### PR DESCRIPTION
On a certain use case the preview URL shown via AJAX misses the slash before the last segment. Preconditions are:
1. Checkbox "Allow standard editors only editing of the last segment of the URL (single page)" is set
2. Editor edited the slug manually. No matter if she (by accident) forgot to keep the leading slash in the input form for the slug or correctly put it there.

Tested with TYPO3 10.4.17 and master branch of sluggi.

![sluggi-slugpreview](https://user-images.githubusercontent.com/11320147/122953172-cd61a280-d37e-11eb-8111-b6a6c2852c35.png)