### PR TITLE
[BUGFIX] Do not try to regenerate slug for non existing site language

### DIFF
--- a/Classes/Backend/Hook/DatamapHook.php
+++ b/Classes/Backend/Hook/DatamapHook.php
@@ -301,6 +301,11 @@ class DatamapHook
             return;
         }
 
+        $langauges = $site->getAllLanguages();
+        if (!array_key_exists($languageId, $langauges)) {
+            return;
+        }
+
         [$siteHost, $sitePath] = $this->getBaseByPageId($site, $pageId, $languageId);
         $currentSlug = BackendUtility::getRecord('pages', $pageId, 'slug')['slug'] ?? '';
         $variant = null;


### PR DESCRIPTION
Steps to reproduce the problem that is fixed by this pull request:

1. Create a site configuration with an additional language
2. Create a page in the Backend and create a translation for that page
3. Now remove the language from the site configuration
4. Edit the page properties of the created page (that still has a translation in the database, not visible in the Backend any more)
5. You get an Exception: "Language 1 does not exist on site my-site."
