### PR TITLE
[BUGFIX] Do not update slug when moving a locked page

### DIFF
--- a/Classes/Backend/Hook/DatamapHook.php
+++ b/Classes/Backend/Hook/DatamapHook.php
@@ -72,8 +72,8 @@ class DatamapHook
 
     protected function updateSlugForMovedPage(int $id, int $targetId, DataHandler $dataHandler): void
     {
-        $currentPage = BackendUtility::getRecord('pages', $id, 'uid, slug, sys_language_uid');
-        if (!empty($currentPage)) {
+        $currentPage = BackendUtility::getRecord('pages', $id, 'uid, slug, sys_language_uid, tx_sluggi_lock');
+        if (!empty($currentPage) && !PermissionHelper::isLocked($currentPage)) {
             $allowOnlyLastSegment = (bool)Configuration::get('last_segment_only');
 
             $currentSlugSegment = SlugHelper::getLastSlugSegment($currentPage['slug']);


### PR DESCRIPTION
Resolves: #46

With this commit one is able to move a page which has tx_sluggi_lock=1 and its slug is not updated. Also the slug of child pages are not updated.

When one moves a page with tx_sluggi_lock=0 (1) whose child has tx_sluggi_lock=1 (2), then page 1 gets a new slug and page 2 slug is not updated.

The same behaviour applies to translated pages, translations having tx_sluggi_lock=1 don't get a new slug.