### PR TITLE
[BUGFIX] Make sure editors don't mess up the slug accidentally

### DIFF
--- a/Classes/Backend/Controller/FormSlugAjaxController.php
+++ b/Classes/Backend/Controller/FormSlugAjaxController.php
@@ -7,6 +7,7 @@ namespace Wazum\Sluggi\Backend\Controller;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\Model\RecordStateFactory;
 use TYPO3\CMS\Core\DataHandling\SlugHelper;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
@@ -114,7 +115,7 @@ class FormSlugAjaxController extends \TYPO3\CMS\Backend\Controller\FormSlugAjaxC
         $mountRootPage = PermissionHelper::getTopmostAccessiblePage($pid);
         $inaccessibleSlugSegments = null;
         if ($mountRootPage !== null) {
-            $inaccessibleSlugSegments = SluggiSlugHelper::getSlug($mountRootPage['pid'], $languageId);
+            $inaccessibleSlugSegments = SluggiSlugHelper::getSlugPath(BackendUtility::getRecordWSOL($tableName, $pid));
         }
 
         return new JsonResponse([

--- a/Classes/Backend/Form/InputSlugElement.php
+++ b/Classes/Backend/Form/InputSlugElement.php
@@ -7,6 +7,7 @@ namespace Wazum\Sluggi\Backend\Form;
 use DOMDocument;
 use DOMNode;
 use DOMXPath;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use Wazum\Sluggi\Helper\Configuration;
 use Wazum\Sluggi\Helper\PermissionHelper;
 use Wazum\Sluggi\Helper\SlugHelper as SluggiSlugHelper;
@@ -48,7 +49,7 @@ class InputSlugElement extends \TYPO3\CMS\Backend\Form\Element\InputSlugElement
             }
 
             $mountRootPage = PermissionHelper::getTopmostAccessiblePage((int)$this->data['databaseRow']['uid']);
-            $inaccessibleSlugSegments = SluggiSlugHelper::getSlug((int)$mountRootPage['pid'], $languageId);
+            $inaccessibleSlugSegments = SluggiSlugHelper::getSlugPath($page);
             $prefix = ($this->data['customData'][$this->data['fieldName']]['slugPrefix'] ?? '') . $inaccessibleSlugSegments;
             $editableSlugSegments = $this->data['databaseRow']['slug'];
             $allowOnlyLastSegment = (bool)Configuration::get('last_segment_only');

--- a/Classes/Backend/Hook/DataHandlerSlugUpdateHook.php
+++ b/Classes/Backend/Hook/DataHandlerSlugUpdateHook.php
@@ -82,7 +82,7 @@ class DataHandlerSlugUpdateHook
         if (isset($incomingFieldArray['tx_sluggi_sync']) && (bool)$incomingFieldArray['tx_sluggi_sync'] === false) {
             $synchronize = false;
         }
-        if (!$locked && $synchronize) {
+        if (!$locked && !$allowOnlyLastSegment && $synchronize) {
             $data = array_merge($record, $incomingFieldArray);
             if ($data['tx_sluggi_sync']) {
                 $fieldConfig = $GLOBALS['TCA']['pages']['columns']['slug']['config'] ?? [];
@@ -94,13 +94,18 @@ class DataHandlerSlugUpdateHook
             $languageId = $record['sys_language_uid'];
             $inaccessibleSlugSegments = $this->getInaccessibleSlugSegments($id, $languageId);
             // Prepend the parent page slug
-            $parentSlug = SluggiSlugHelper::getSlug($record['pid'], $languageId);
+            $parentSlug = SluggiSlugHelper::getSlugPath($record);
             if (false !== strpos(substr($incomingFieldArray['slug'], 1), '/')) {
                 $this->setFlashMessage(
                     LocalizationUtility::translate('message.slashesNotAllowed', 'sluggi'),
                     FlashMessage::WARNING
                 );
             }
+            // make sure manually edited slug starts with /
+            if (strncmp($incomingFieldArray['slug'], '/', 1) !== 0) {
+                $incomingFieldArray['slug'] = '/' . $incomingFieldArray['slug'];
+            }
+
             $incomingFieldArray['slug'] = $inaccessibleSlugSegments .
                 str_replace($inaccessibleSlugSegments, '', $parentSlug) .
                 '/' . str_replace('/', '-', substr($incomingFieldArray['slug'], 1));
@@ -161,7 +166,7 @@ class DataHandlerSlugUpdateHook
     {
         $mountRootPage = PermissionHelper::getTopmostAccessiblePage($pageId);
 
-        return SluggiSlugHelper::getSlug($mountRootPage['pid'], $languageId);
+        return SluggiSlugHelper::getSlugPath(BackendUtility::getRecordWSOL('pages', $pageId));
     }
 
     protected function setFlashMessage(string $text, int $severity): void

--- a/Classes/Helper/SlugHelper.php
+++ b/Classes/Helper/SlugHelper.php
@@ -21,6 +21,21 @@ use function explode;
 class SlugHelper
 {
     /**
+     * Return correct slug path in case a short slug - not matching the page tree - is used
+     */
+    public static function getSlugPath($pageRecord) {
+        // if we have a first level slug (aka short url), we need no parent path info
+        if (strlen($pageRecord['slug']) < 2 || substr_count($pageRecord['slug'], '/', 1) === 0) {
+            return '';
+        }
+        /** @var \TYPO3\CMS\Core\DataHandling\SlugHelper $slugHelper */
+        $slugHelper = GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\SlugHelper::class, 'pages', 'slug', $GLOBALS['TCA']['pages']['columns']['slug']['config']);
+        $inaccessibleSlugSegments = $slugHelper->generate($pageRecord, $pageRecord['pid']);
+        // chop off part for current page
+        return substr($inaccessibleSlugSegments,0,strrpos($inaccessibleSlugSegments,'/'));
+    }
+
+    /**
      * Return slug for given page ID
      */
     public static function getSlug(int $pageId, int $languageId = 0): string


### PR DESCRIPTION
- Make sure prepending slash is not forgotten (EDIT: that seems to be fixed meanwhile)
- Keep parent path correctly if it does not match the tree rootline (aka is shortened)
- Show fixed part of slug correctly also if it is shortened