### PR TITLE
[FEATURE] Add switch for default-state of tx_sluggi_sync for new pages

### DIFF
--- a/Classes/Backend/Hook/DataHandlerSlugUpdateHook.php
+++ b/Classes/Backend/Hook/DataHandlerSlugUpdateHook.php
@@ -54,6 +54,15 @@ class DataHandlerSlugUpdateHook
         DataHandler $dataHandler
     ): void {
         if (
+            'pages' === $table && !MathUtility::canBeInterpretedAsInteger($id)){
+                //new page was created
+                $synchronizeOn = (bool) Configuration::get('synchronize_on');
+                if ($synchronizeOn){
+                    $incomingFieldArray['tx_sluggi_sync'] = 1;
+                }
+                return;
+            }
+        if (
             'pages' !== $table
             // This is set in \TYPO3\CMS\Backend\History\RecordHistoryRollback::performRollback,
             // so we use it as a flag to ignore the update

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -83,7 +83,7 @@ if (!function_exists('array_flatten')) {
                         'labelUnchecked' => 'LLL:EXT:sluggi/Resources/Private/Language/locallang.xlf:pages.tx_sluggi_sync.disabled'
                     ]
                 ],
-                'default' => 1
+                'default' => 0
             ]
         ]
     ];

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -6,5 +6,7 @@ slash_replacement = 1
 pages_fields = [["nav_title","title"]]
 # cat=basic; type=boolean; label=Enable synchronization of slug segment with configured page fields
 synchronize = 1
+# cat=basic; type=boolean; label=Turn on synchronization of slug segment with configured page fields
+synchronize_on = 0
 # cat=basic; type=boolean; label=Allow standard editors only editing of the last segment of the URL (single page)
 last_segment_only = 0

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -3,5 +3,5 @@
 #
 CREATE TABLE pages (
   tx_sluggi_lock SMALLINT(5) UNSIGNED DEFAULT '0' NOT NULL,
-  tx_sluggi_sync SMALLINT(5) UNSIGNED DEFAULT '1' NOT NULL
+  tx_sluggi_sync SMALLINT(5) UNSIGNED DEFAULT '0' NOT NULL
 );


### PR DESCRIPTION
quick & dirty implementation of a config-option to set the default state of tx_sluggi_sync for new pages.
implemented against the typo3-10 branch. 