### PR TITLE
[BUGFIX:BP:11] Avoid unacceptable slug changes on locked slugs

### DIFF
--- a/Classes/Backend/Form/InputSlugElement.php
+++ b/Classes/Backend/Form/InputSlugElement.php
@@ -73,7 +73,7 @@ final class InputSlugElement extends \TYPO3\CMS\Backend\Form\Element\InputSlugEl
         if (!empty($inaccessibleSlugSegments) && 0 === strncmp($editableSlugSegments, $inaccessibleSlugSegments, strlen($inaccessibleSlugSegments))) {
             $editableSlugSegments = substr($editableSlugSegments, strlen($inaccessibleSlugSegments));
         }
-        if ($allowOnlyLastSegment && !empty($editableSlugSegments)) {
+        if ($allowOnlyLastSegment && !($this->data['databaseRow']['slug_locked']) && !empty($editableSlugSegments)) {
             $segments = explode('/', $editableSlugSegments);
             $editableSlugSegments = '/' . array_pop($segments);
             $prefix .= implode('/', $segments);

--- a/Classes/DataHandler/HandlePageUpdate.php
+++ b/Classes/DataHandler/HandlePageUpdate.php
@@ -66,7 +66,7 @@ final class HandlePageUpdate implements LoggerAwareInterface
 
         if ($this->shouldSynchronize($pageRecord, $fields)) {
             $fields = $this->synchronize($pageRecord, $fields);
-        } elseif ($this->isManualUpdateWithOnlyLastSegmentAllowed($fields)) {
+        } elseif ($this->isManualUpdateWithOnlyLastSegmentAllowed($fields) && !($pageRecord['slug_locked'])) {
             $fields = $this->updateLastSegment($pageRecord, $fields);
         }
     }


### PR DESCRIPTION
EXT:sluggi always(on each pages change) rewrites the slug with path segments to the last path segment, even the slug is locked and not changed by editor. Also from `/virtual-parent-slug/my-test-page` to `/my-test-page`. This change prevents overrides on slugs at least on "locked" slugs.

**Note: This is a partial fix only and not locked slugs will be still overridden.**

Relates: #98
Ports: #99