### PR TITLE
[BUGFIX] Fixed last_segment_only functionality on new pages created through context menu by adding new HandleNewPage datahandler hook and updated element and ajax call

### DIFF
--- a/Classes/Backend/Controller/FormSlugAjaxController.php
+++ b/Classes/Backend/Controller/FormSlugAjaxController.php
@@ -90,8 +90,12 @@ final class FormSlugAjaxController extends \TYPO3\CMS\Backend\Controller\FormSlu
                 $proposal = preg_replace('#(?<!^)/(?!$)#', '-', $proposal);
 
                 $pageRecord = BackendUtility::getRecordWSOL('pages', $recordId);
-                $parts = \explode('/', $pageRecord['slug']);
-                array_pop($parts);
+                if ($pageRecord === null) {
+                    $parts = \explode('/', SluggiSlugHelper::getSlug($pid, $languageId));
+                } else {
+                    $parts = \explode('/', $pageRecord['slug']);
+                    array_pop($parts);
+                }
                 $proposal = rtrim(implode('/', $parts), '/') . '/' . ltrim($proposal, '/');
             }
         } else {

--- a/Classes/Backend/Form/InputSlugElement.php
+++ b/Classes/Backend/Form/InputSlugElement.php
@@ -71,15 +71,21 @@ final class InputSlugElement extends \TYPO3\CMS\Backend\Form\Element\InputSlugEl
     {
         $languageId = $this->getLanguageId($this->data['tableName'], $this->data['databaseRow']);
         $mountRootPage = PermissionHelper::getTopmostAccessiblePage((int) $this->data['databaseRow']['uid']);
+        $allowOnlyLastSegment = (bool) Configuration::get('last_segment_only');
+
         // This is the case when a new page is generated through the context menu
         if (null === $mountRootPage) {
+            if ($allowOnlyLastSegment) {
+                $parentSlug = SluggiSlugHelper::getSlug((int)$this->data['databaseRow']['pid'], $languageId);
+                $prefix = ($this->data['customData'][$this->data['fieldName']]['slugPrefix'] ?? '') . $parentSlug;
+                $result['html'] = $this->replaceValues($result['html'], $prefix, '');
+            }
             return $result;
         }
 
         $inaccessibleSlugSegments = SluggiSlugHelper::getSlug((int) $mountRootPage['pid'], $languageId);
         $prefix = ($this->data['customData'][$this->data['fieldName']]['slugPrefix'] ?? '') . $inaccessibleSlugSegments;
         $editableSlugSegments = $this->data['databaseRow']['slug'];
-        $allowOnlyLastSegment = (bool) Configuration::get('last_segment_only');
         if (!empty($inaccessibleSlugSegments) && str_starts_with($editableSlugSegments, $inaccessibleSlugSegments)) {
             $editableSlugSegments = substr($editableSlugSegments, strlen($inaccessibleSlugSegments));
         }

--- a/Classes/DataHandler/HandleNewPage.php
+++ b/Classes/DataHandler/HandleNewPage.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wazum\Sluggi\DataHandler;
+
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use Wazum\Sluggi\Helper\Configuration;
+use Wazum\Sluggi\Helper\PermissionHelper;
+use Wazum\Sluggi\Helper\SlugHelper;
+
+final class HandleNewPage
+{
+    public function processDatamap_preProcessFieldArray(
+        array &$fields,
+        string $table,
+        string|int $id,
+        DataHandler $dataHandler
+    ): void {
+        if (!$this->shouldRun($table, $id, $fields)) {
+            return;
+        }
+
+        $lastSegment = SlugHelper::getLastSlugSegment($fields['slug']);
+        $languageId = (int)($fields['sys_language_uid'] ?? 0);
+        $parentSlug = SlugHelper::getSlug((int)$fields['pid'], $languageId);
+
+        $fields['slug'] = \rtrim($parentSlug, '/') . $lastSegment;
+    }
+
+    private function shouldRun(string $table, string|int $id, array $fields): bool
+    {
+        $pid = (int)($fields['pid'] ?? 0);
+        // Only run for new pages with valid pid
+        if ($table !== 'pages' || (int)$id !== 0 || !($pid > 0)) {
+            return false;
+        }
+
+        // Only run if the slug field is set
+        if (empty($fields['slug'] ?? '')) {
+            return false;
+        }
+
+        // Only run if the user does not have full permissions and last_segment_only is enabled
+        $lastSegmentOnly = (bool)Configuration::get('last_segment_only');
+        return $lastSegmentOnly && !PermissionHelper::hasFullPermission();
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,6 +10,7 @@ use Wazum\Sluggi\Backend\Form\InputTextWithSlugImpactElement;
 use Wazum\Sluggi\Backend\FormDataProvider;
 use Wazum\Sluggi\Backend\PageRendererRenderPreProcess;
 use Wazum\Sluggi\DataHandler\HandleExcludeSlugForSubpages;
+use Wazum\Sluggi\DataHandler\HandleNewPage;
 use Wazum\Sluggi\DataHandler\HandlePageCopy;
 use Wazum\Sluggi\DataHandler\HandlePageMove;
 use Wazum\Sluggi\DataHandler\HandlePageUpdate;
@@ -41,6 +42,9 @@ if (!function_exists('array_flatten')) {
 
 (static function (): void {
     // Register some DataHandler hooks for page related actions
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['sluggi-new']
+        = HandleNewPage::class;
+
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['sluggi-update']
         = HandlePageUpdate::class;
 


### PR DESCRIPTION
This PR may not cover all cases / problems but these changes fix problems with creating new pages through the context menu ("New subpage") when the `last_segment_only` configuration is set and the backend user does not have full permissions.

- `FormSlugAjaxController`
  - If the editor does a `manual` update but the `$pageRecord` is null (this is the case when the page has a `NEW...` id) the slug from the parent page is used to prefix the slug proposal
- `InputSlugElement`
  - The `null === $mountRootPage` was introduced specifically for this use case but that meant that there was no slug-prefix visible for new pages through the context menu, it now retrieves the parent page (if `last_segment_only` is set) and prefixes that
- `HandleNewPage`
  - This is a new datahandler hook specifically for new pages when the `last_segment_only` is set. It retrieves the last segment from the input slug (so if someone enters `foo/bar` only `bar` is taken) and automatically prefixes the slug from the parent page before saving.
    - This prevents the slug from being set as a "root" url

Fixes #101 #93 