### PR TITLE
[BUGFIX] #123 Fix SlugLockUpgradeWizard for Typo3 ^13.4.19

### DIFF
--- a/Classes/Upgrade/SlugLockUpgradeWizard.php
+++ b/Classes/Upgrade/SlugLockUpgradeWizard.php
@@ -37,7 +37,7 @@ final class SlugLockUpgradeWizard implements UpgradeWizardInterface
     public function updateNecessary(): bool
     {
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
-        $tableInformation = $connection->getSchemaInformation()->introspectTable('pages');
+        $tableInformation = $connection->createSchemaManager()->introspectTable('pages');
         if ($tableInformation->hasColumn('tx_sluggi_lock')) {
             $queryBuilder = $this->getPagesQueryBuilder();
 


### PR DESCRIPTION
Replaces the call to the internal TYPO3 Database Schema/Introspection API that was refactored in v13.4.19 by calling Doctrine DBAL Schema/Introspection API directly.

Verified the change by running
`vendor/bin/typo3 upgrade:mark:undone sluggi_slugLockUpgradeWizard` and `upgrade:run` while checking the output of the hasColumn Call against databases with and without the tx_sluggi_lock column.