### PR TITLE
[BUGFIX] Fix Setup module exception on TYPO3 v14

### DIFF
--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+// addUserSetting() was introduced in TYPO3 v14.3. Older TYPO3 versions
+// register the field through the legacy API in ext_tables.php.
+if (!method_exists(ExtensionManagementUtility::class, 'addUserSetting')) {
+    return;
+}
+
+ExtensionManagementUtility::addUserSetting(
+    'sluggiCollapsedControls',
+    [
+        'label' => 'LLL:EXT:sluggi/Resources/Private/Language/locallang.xlf:userSettings.collapsedControls',
+        'config' => [
+            'type' => 'check',
+            'renderType' => 'checkboxToggle',
+        ],
+    ],
+    'after:showHiddenFilesAndFolders'
+);

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
+// TYPO3 v14.3+ registers this field via the TCA-based addUserSetting() API in
+// Configuration/TCA/Overrides/be_users.php. The legacy registration below is
+// only used for TYPO3 v12 and v13.
+if (method_exists(ExtensionManagementUtility::class, 'addUserSetting')) {
+    return;
+}
+
 $GLOBALS['TYPO3_USER_SETTINGS']['columns']['sluggiCollapsedControls'] = [
     'type' => 'check',
     'label' => 'LLL:EXT:sluggi/Resources/Private/Language/locallang.xlf:userSettings.collapsedControls',


### PR DESCRIPTION
Fixes #140 

## What

Register `sluggiCollapsedControls` through the new `ExtensionManagementUtility::addUserSetting()` API in a new `Configuration/TCA/Overrides/be_users.php`, using the TCA-style shape (`label` + nested `config` with `type` and `renderType`).

The legacy registration in `ext_tables.php` is kept behind a `method_exists(ExtensionManagementUtility::class, 'addUserSetting')` guard so TYPO3 v12 and v13 continue to work unchanged.

## Why

TYPO3 v14.3 migrated backend user settings to TCA and now renders them through FormEngine, which expects every column to carry a nested `config` array. The legacy flat `$GLOBALS['TYPO3_USER_SETTINGS']` format produced by sluggi triggers `Undefined array key "config"` (exception #1476107295) when the Setup module is opened. `addFieldsToUserSettings()` is also deprecated since v14.3 and slated for removal in v15.

References:
- [Feature: #108843 - User settings configuration migrated to TCA](https://docs.typo3.org/permalink/changelog:feature-108843-1738600001)
- [Deprecation: #108843 - ExtensionManagementUtility::addFieldsToUserSettings](https://docs.typo3.org/permalink/changelog:deprecation-108843-1738600000)